### PR TITLE
Javascript texture packer

### DIFF
--- a/orx/exporter.xml
+++ b/orx/exporter.xml
@@ -9,7 +9,7 @@
     <description>Orx Exporter</description>
 
     <!-- exporter version -->
-    <version>1.0</version>
+    <version>1.1</version>  
 
     <!-- currently only one file allowed - more to come with update -->
     <files>
@@ -46,4 +46,31 @@
     <!-- supports texure subpath -->
     <supportsTextureSubPath>yes</supportsTextureSubPath>
 
+    <supportsPivotPoint>true</supportsPivotPoint>
+
+    <supportsAnimations>true</supportsAnimations>
+	
+	<properties>
+        <property>
+            <name>includeComments</name>
+            <type>bool</type>
+            <displayName>Include comments</displayName>
+            <toolTip>Output comments in produced result.</toolTip>
+            <isAdvanced>true</isAdvanced>
+        </property>
+        <property>
+            <name>keepInCache</name>
+            <type>bool</type>
+            <displayName>Keep in cache</displayName>
+            <toolTip>Keep textures and animations in cache.</toolTip>
+            <default>false</default>
+        </property>
+        <property>
+            <name>keyDuration</name>
+            <type>string</type>
+            <displayName>Key duration</displayName>
+            <toolTip>Animation key duration in seconds.</toolTip>
+            <default>0.15</default>
+        </property>
+    </properties>
 </exporter>

--- a/orx/exporter.xml
+++ b/orx/exporter.xml
@@ -68,6 +68,13 @@
             <isAdvanced>true</isAdvanced>
         </property>
         <property>
+            <name>optimizeSectionNames</name>
+            <type>bool</type>
+            <displayName>Optimize section names</displayName>
+            <toolTip>Optimize image paths to pascal-cased section names.</toolTip>
+            <default>true</default>
+        </property>
+        <property>
             <name>keepInCache</name>
             <type>bool</type>
             <displayName>Keep in cache</displayName>
@@ -79,7 +86,7 @@
             <type>string</type>
             <displayName>Key duration</displayName>
             <toolTip>Animation key duration in seconds.</toolTip>
-            <default>0.15</default>
+            <default>0.1</default>
         </property>
     </properties>
 </exporter>

--- a/orx/exporter.xml
+++ b/orx/exporter.xml
@@ -50,7 +50,16 @@
 
     <supportsAnimations>true</supportsAnimations>
 	
-	<properties>
+	<!-- You can specify default values for the following TexturePacker settings.
+         They are used if a new project is created or if the data format of
+         an existing project is changed and "Update to recommended values"
+         is checked. The complete <defaults> block is optional. -->
+    <defaults>
+        <writePivotPoints>true</writePivotPoints>
+        <defaultPivotPoint>0.5,0.5</defaultPivotPoint>
+    </defaults>
+    
+    <properties>
         <property>
             <name>includeComments</name>
             <type>bool</type>

--- a/orx/exporter.xml
+++ b/orx/exporter.xml
@@ -75,11 +75,20 @@
             <default>true</default>
         </property>
         <property>
+            <name>pixelSnap</name>
+            <type>bool</type>
+            <displayName>Pixel-snap pivot points</displayName>
+            <toolTip>Snap center pivot points to whole pixels.</toolTip>
+            <default>false</default>
+            <isAdvanced>true</isAdvanced>
+        </property>
+        <property>
             <name>keepInCache</name>
             <type>bool</type>
             <displayName>Keep in cache</displayName>
             <toolTip>Keep textures and animations in cache.</toolTip>
             <default>false</default>
+            <isAdvanced>true</isAdvanced>
         </property>
         <property>
             <name>keyDuration</name>
@@ -87,6 +96,7 @@
             <displayName>Key duration</displayName>
             <toolTip>Animation key duration in seconds.</toolTip>
             <default>0.1</default>
+            <isAdvanced>true</isAdvanced>
         </property>
     </properties>
 </exporter>

--- a/orx/grantlee/0.2/OrxJs.qs
+++ b/orx/grantlee/0.2/OrxJs.qs
@@ -82,6 +82,14 @@ function sortByName(arr) {
     });
 }
 
+function pivotToString(sprite) {
+    var pivot = normPointToString(sprite.pivotPointNorm);
+    if (pivot === undefined) {
+        pivot = pointToString(sprite.pivotPoint);
+    }
+    return pivot;
+}
+
 function normPointToString(point) {
     if (point.x == 0.5 && point.y == 0.5)
         return 'center';
@@ -93,8 +101,8 @@ function normPointToString(point) {
         return 'top|right';
     if (point.x == 0.0 && point.y == 1.0)
         return 'bottom|left';
-  
-    return pointToString(point);
+    
+    // orx wants absolute coordinates!
 }
 
 function sizeToString(size) {
@@ -127,7 +135,7 @@ function printFrame(root, sprite, id, parentId) {
            tag('TextureSize', sizeToString(sprite.frameRect)));
 
     if (root.settings.writePivotPoints) {
-        append(tag('Pivot', normPointToString(sprite.pivotPointNorm)));
+        append(tag('Pivot', pivotToString(sprite)));
     }
     append();
 }

--- a/orx/grantlee/0.2/OrxJs.qs
+++ b/orx/grantlee/0.2/OrxJs.qs
@@ -288,15 +288,6 @@ function printFrames(root) {
         for (var j = 0; j < sprites.length; j++) {
             var sprite = sprites[j];
             
-            /*if (frameData[j].animation) {
-                append(sprite.fullName);
-                append('     cornerOffset  ' + pointToString(sprite.cornerOffset));
-                append('     size          ' + sizeToString(sprite.size));
-                append('     untrimmedSize ' + sizeToString(sprite.untrimmedSize));
-                append('     frameRect     ' + sizeToString(sprite.frameRect));
-                append('     sourceRect    ' + sizeToString(sprite.sourceRect));
-            }*/
-            
             printAnimation(root, sprite, texture, frameData[j]);
         }
         

--- a/orx/grantlee/0.2/OrxJs.qs
+++ b/orx/grantlee/0.2/OrxJs.qs
@@ -1,0 +1,272 @@
+var buffer = '';
+
+function append() {
+    for (var i = 0; i < arguments.length; i++) {
+        if (arguments[i] !== undefined) {
+            buffer += arguments[i] + '\n';
+        }
+    }
+    if (arguments.length == 0) {
+        buffer += '\n';
+    }
+}
+
+function friendlyName(name) {
+    name = name.replace(/[^a-z0-9]/gi, ' ');        // Keep alpha-numeric
+    name = name[0].toUpperCase() + name.slice(1); // Proper case
+    return name;
+}
+
+function getId(name) {
+    // 'big enemy/hard-boss/boss_01' -> ['big', 'enemy', 'hard', 'boss', 'boss', '01']
+    var parts = name.split(/\/|_|-| /g);
+    
+    for (var i = 0; i < parts.length; i++) {
+        parts[i] = friendlyName(parts[i]);
+    }
+    
+    // Optimize any sequences of the same identifier.
+    // E.g. ['Boss', 'Boss', 'Boss'] -> 'Boss'
+    var clean = parts[0];
+    for (var i = 1; i < parts.length; i++) {
+        if (parts[i] !== parts[i - 1]) {
+            clean += parts[i];
+        }
+    }
+    
+    // Now we have an identifier suitable for .ini files.
+    // E.g. 'BigEnemyHardBoss01'
+    
+    return clean;
+}
+
+function section(id) {
+    return '[' + id + ']';
+}
+
+function frameSection(root, sprite, id, parentId) {
+    var frameId = id;
+    if (parentId !== undefined) {
+        frameId += '@' + parentId;
+    }
+    result = section(frameId);
+
+    if (root.exporterProperties.includeComments) {
+        result += ' ; Source: ' + sprite.fullName;
+    }
+    
+    return result;
+}
+
+function tagIf(key, value, condition) {
+    if (condition) {
+        return tag(key, value);
+    }
+}
+
+function tag(key, value) {
+    var maxTagLength = 13; // I.e. TextureOrigin
+    while (key.length < maxTagLength) {
+        key += ' ';
+    }
+    return key + ' = ' + value;
+}
+
+function pointToString(point) {
+    return '(' + point.x + ', ' + point.y + ')';
+}
+
+function sortByName(arr) {
+    return arr.slice().sort(function(a, b) {
+        return a.trimmedName.localeCompare(b.trimmedName);
+    });
+}
+
+function normPointToString(point) {
+    if (point.x == 0.5 && point.y == 0.5)
+        return 'center';
+    if (point.x == 0.0 && point.y == 0.0)
+        return 'top|left';
+    if (point.x == 1.0 && point.y == 1.0)
+        return 'bottom|right';
+    if (point.x == 1.0 && point.y == 0.0)
+        return 'top|right';
+    if (point.x == 0.0 && point.y == 1.0)
+        return 'bottom|left';
+  
+    return pointToString(point);
+}
+
+function sizeToString(size) {
+    return '(' + size.width + ', ' + size.height + ')';
+}
+
+function printAnimation(root, sprite, texture, frameCount) {
+    if (!root.settings.autodetectAnimations || frameCount < 2) {
+        return;
+    }
+    
+    var animationSetid = getContainerId(sprite.trimmedName, 'animation-set');
+    var animId = getContainerId(sprite.trimmedName, 'anim');
+    
+    append(section(animationSetid),
+           tag('Texture', texture.fullName),
+           tagIf('KeepInCache', true, root.exporterProperties.keepInCache),
+           tag('FrameSize', sizeToString(sprite.untrimmedSize)),
+           tag('KeyDuration', root.exporterProperties.keyDuration),
+           tag('Digits', digitCount(frameCount)),
+           tag('StartAnim', animId),
+           tag(animId, frameCount));
+    
+    append();
+}
+
+function printFrame(root, sprite, id, parentId) {
+    append(frameSection(root, sprite, id, parentId),
+           tag('TextureOrigin', pointToString(sprite.frameRect)),
+           tag('TextureSize', sizeToString(sprite.frameRect)));
+
+    if (root.settings.writePivotPoints) {
+        append(tag('Pivot', normPointToString(sprite.pivotPointNorm)));
+    }
+    append();
+}
+
+function pad(num, size) {
+    return ('000000000' + num).substr(-size);
+}
+
+function digitCount(num) {
+    return num.toString().length;
+}
+
+function getFrameInfo(root, sprite, texture, frameData) {
+    var name = sprite.trimmedName;
+    var parentId;
+    
+    if (root.settings.autodetectAnimations && frameData.frameCount > 1) {
+        var size = digitCount(frameData.frameCount);
+        var anim = 'anim' + pad(frameData.frameNo, size);
+
+        name = getContainerId(name, anim);
+    } else {
+        parentId = getId(texture.trimmedName);
+    }
+    
+    return {
+        id: getId(name),
+        parentId: parentId
+    };
+}
+
+function getContainerId(name, suffix) {
+    name = name.replace(/\d+$/gi, suffix);
+    
+    return getId(name);
+}
+
+function getPath(name) {
+    return name.replace(/\/[^\/]+$/g, '');
+}
+
+function sizeEqual(a, b) {
+    if (a === undefined || b === undefined) {
+        return false;
+    }
+    
+    return a.width == b.width && a.height == b.height;
+}
+
+function isNewFrameSet(sprite, prevSprite) {
+    if (prevSprite === undefined) {
+        return true;
+    }
+    var path = getPath(sprite.trimmedName);
+    var size = sprite.untrimmedSize;
+    var prevPath = getPath(prevSprite.trimmedName);
+    var prevSize = prevSprite.untrimmedSize;
+    
+    return (path !== prevPath || !sizeEqual(size, prevSize));
+}
+
+function getFrameData(root, sprites) {
+    var results = [];
+    
+    var start = 0, current = 0;
+    var prevSprite;
+    
+    for (var i = 0; i < sprites.length; i++) {
+        var sprite = sprites[i];
+        if (isNewFrameSet(sprite, prevSprite)) {
+            start = i;
+            current = 0;
+            prevSprite = sprite;
+        }
+        
+        results.push({
+            frameNo: ++current
+        });
+    
+        for (var j = start; j <= i; j++) {
+            results[j].frameCount = current;
+        }
+    }
+    
+    return results;
+}
+
+function printFrames(root) {
+    var textures = root.allResults[root.variantIndex].textures;
+        
+    for (var i = 0; i < textures.length; i++) {
+        var texture = textures[i];
+        var sprites = sortByName(texture.sprites);
+        
+        var frameData = getFrameData(root, sprites);
+        
+        for (var j = 0; j < sprites.length; j++) {
+            // Only generate animation set for the first frame!
+            if (frameData[j].frameNo == 1) {
+                var sprite = sprites[j];
+                printAnimation(root, sprite, texture, frameData[j].frameCount);
+            }    
+        }
+        
+        for (var j = 0; j < sprites.length; j++) {
+            var sprite = sprites[j];
+            var info = getFrameInfo(root, sprite, texture, frameData[j]);
+            
+            printFrame(root, sprite, info.id, info.parentId);
+        }
+    }
+}
+
+function printTexture(root, texture) {
+    var id = getId(texture.trimmedName);
+    append(section(id),
+           tag('Texture', texture.fullName),
+           tag('TextureSize', sizeToString(texture.size)),
+           tagIf('KeepInCache', true, root.exporterProperties.keepInCache));
+    
+    append();
+}
+
+function printTextures(root) {
+    var textures = root.allResults[root.variantIndex].textures;
+    
+    for (var i = 0; i < textures.length; i++) {
+        printTexture(root, textures[i]);
+    }
+}
+
+var ExportData = function(root) {
+    buffer = '';
+    
+    printTextures(root);
+    printFrames(root);
+    
+    return buffer;
+}
+
+ExportData.filterName = 'exportData';
+Library.addFilter('ExportData');

--- a/orx/orx.ini
+++ b/orx/orx.ini
@@ -1,15 +1,5 @@
 ; Created with TexturePacker (http://www.texturepacker.com)
 ; {{smartUpdateKey}}
 
-[{{texture.trimmedName}}]
-Texture = {{texture.fullName}}
-TextureSize = ({{texture.size.width}}, {{texture.size.height}}, 0)
-{% for sprite in allSprites %}
-{% if settings.textureSubPath %}[{{sprite.trimmedName}}_{{settings.textureSubPath}}@{{texture.trimmedName}}]{% else %}[{{sprite.trimmedName}}@{{texture.trimmedName}}]{% endif %}
-{% if sprite.trimmed %}Pivot = ({%ifequal sprite.cornerOffset.x 0 %}0{% else %}-{{sprite.cornerOffset.x}}{% endifequal %}, {%ifequal sprite.cornerOffset.y 0 %}0{% else %}-{{sprite.cornerOffset.y}}{% endifequal %}, 0)
-{% endif %}TextureOrigin = ({{sprite.frameRect.x}}, {{sprite.frameRect.y}}, 0)
-TextureSize = ({{sprite.frameRect.width}}, {{sprite.frameRect.height}}, 0)
-{% if sprite.isSolid %}BlendMode = none
-{% else %}{% if settings.premultiplyAlpha %}BlendMode = premul
-{% endif %}{% endif %}{% if sprite.rotated %}Orientation = right
-{% endif %}{% endfor %}
+{% load OrxJs %}
+{{tp|exportData}}


### PR DESCRIPTION
Complete rewrite of the old `orx` texture packer for [CodeAndWeb Texture Packer](https://www.codeandweb.com/texturepacker). Note that `Grantlee` support is ending soon. Hence the complete rewrite!

**Support for:**

- Pivot. With friendly names like `center` where applicable.
- Animations. Numbered, equally sized images in the same folder _may_ be owned by a generated animation set (controlled by setting).
- Extra settings: _Include comments_, _Keep in cache_ (my favorite) and _Key duration_ will prove useful!
- Proper indenting.
- Proper naming. Styling adapted from [orx tutorials](https://wiki.orx-project.org/en/tutorials/main).