### PR TITLE
Changes to support trimmed sprite animation

### DIFF
--- a/orx/grantlee/0.2/OrxJs.qs
+++ b/orx/grantlee/0.2/OrxJs.qs
@@ -91,10 +91,20 @@ function sortByName(arr) {
 }
 
 function pivotToString(root, sprite) {
-    var pivot = normPointToString(root, sprite.pivotPointNorm);
-    if (pivot === undefined) {
-        pivot = pointToString(sprite.pivotPoint);
+    var pivot;
+    if(sprite.pivotPoint !== undefined && sprite.trimmed === true) {
+        pivot = sprite.pivotPoint;
+        pivot.x = pivot.x - sprite.cornerOffset.x;
+        pivot.y = pivot.y - sprite.cornerOffset.y;
+        return pointToString(pivot);
+    } 
+    else {
+        pivot = normPointToString(root, sprite.pivotPointNorm);
+        if (pivot === undefined) {
+            pivot = pointToString(sprite.pivotPoint);
+        }
     }
+        
     return pivot;
 }
 
@@ -150,7 +160,6 @@ function printAnimation(root, sprite, texture, frameData) {
            tag('Texture', '@' + textureId),
            tagIf('TextureOrigin', pointToString(sprite.frameRect), frameData.skippedFrames),
            tagIf('FrameSize', sizeToString(sprite.size), frameData.skippedFrames),
-           tagIf('Pivot', pivotToString(root, sprite), root.settings.writePivotPoints),
            tag('KeyDuration', root.exporterProperties.keyDuration),
            tag('StartAnim', animId),
            tagIf(animId, frameData.frameCount, frameData.skippedFrames)); // Required only if there are frames with no texture coordinates!
@@ -170,7 +179,7 @@ function printFrame(root, sprite, texture, frameData) {
            tagIf('Texture', '@' + textureId, !frameData.animation),
            tag('TextureOrigin', pointToString(sprite.frameRect)),
            tagIf('TextureSize', sizeToString(sprite.frameRect), !frameData.skippedFrames), // FrameSize already set?
-           tagIf('Pivot', pivotToString(root, sprite), root.settings.writePivotPoints && !frameData.animation));
+           tagIf('Pivot', pivotToString(root, sprite), root.settings.writePivotPoints));
     
     append();
 }

--- a/orx/grantlee/0.2/OrxJs.qs
+++ b/orx/grantlee/0.2/OrxJs.qs
@@ -92,7 +92,7 @@ function sortByName(arr) {
 
 function pivotToString(root, sprite) {
     var pivot;
-    if(sprite.pivotPoint !== undefined && sprite.trimmed === true) {
+    if (sprite.pivotPoint !== undefined && sprite.trimmed === true) {
         pivot = sprite.pivotPoint;
         pivot.x = pivot.x - sprite.cornerOffset.x;
         pivot.y = pivot.y - sprite.cornerOffset.y;


### PR DESCRIPTION
Trimmed sprite animations now calculate the correct pivot point. Also, previously frames were not exporting pivot and it was on the animation set itself.